### PR TITLE
Amélioration du SEO pour la pagination

### DIFF
--- a/src/Controller/ArticlesAction.php
+++ b/src/Controller/ArticlesAction.php
@@ -19,6 +19,10 @@ final class ArticlesAction extends AbstractController
     #[Route(path: '/articles', name: 'articles_list', methods: 'GET')]
     public function __invoke(Request $request): Response
     {
+        // Redirection de /articles?page=1 vers /articles
+        if ($request->query->has('page') && $request->query->getInt('page') === 1) {
+            return $this->redirectToRoute('articles_list', status: Response::HTTP_MOVED_PERMANENTLY);
+        }
         $page = $request->query->getInt('page', 1);
 
         $articlesPage = $this->planeteApi->getArticles($page);

--- a/templates/articles.html.twig
+++ b/templates/articles.html.twig
@@ -1,5 +1,26 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}Planète PHP{% if page > 1 %} - page {{ page }}{% endif %}{% endblock %}
+
+{% block head %}
+
+    {% if page == 2 %}
+        <link rel="prev" href="{{ path('articles_list') }}" />
+    {% elseif page > 1 %}
+        <link rel="prev" href="{{ path('articles_list', {page: page - 1}) }}" />
+    {% endif %}
+
+    {% if page == 1 %}
+        <link rel="canonical" href="{{ path('articles_list') }}" />
+    {% else %}
+        <link rel="canonical" href="{{ path('articles_list', {page: page}) }}" />
+    {% endif %}
+
+    {% if hasNextPage %}
+        <link rel="next" href="{{ path('articles_list', {page: page + 1}) }}" />
+    {% endif %}
+{% endblock %}
+
 {% block body %}
 
     <div class="flex flex-col gap-4 mt-4 sm:mt-0">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -9,6 +9,9 @@
         <link rel="icon" href="{{ asset('images/veille-logo.svg') }}" sizes="any" type="image/svg+xml">
 
         <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ path('rss') }}">
+
+        {% block head %}
+        {% endblock %}
 
         {% block stylesheets %}
             <link rel="stylesheet" href="{{ asset('styles/app.css') }}">

--- a/tests/ArticleListTest.php
+++ b/tests/ArticleListTest.php
@@ -2,7 +2,11 @@
 
 namespace App\Tests;
 
+use PHPUnit\Framework\Constraint\LogicalAnd;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorAttributeValueSame;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorExists;
 
 class ArticleListTest extends WebTestCase
 {
@@ -63,5 +67,36 @@ class ArticleListTest extends WebTestCase
 
         self::assertSelectorNotExists('[data-qa="page-next"]');
         self::assertSelectorExists('[data-qa="page-prev"]');
+    }
+
+    public function test_seo_pagination_root_url(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/articles');
+
+        self::assertPageTitleSame('Planète PHP');
+        self::assertSelectorNotExists('link[rel="prev"]');
+        self::asserAttributeValueSame($client, 'link[rel="canonical"]', 'href', '/articles');
+        self::asserAttributeValueSame($client, 'link[rel="next"]', 'href', '/articles?page=2');
+    }
+
+
+    public function test_seo_pagination(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/articles?page=2');
+
+        self::assertPageTitleSame('Planète PHP - page 2');
+        self::asserAttributeValueSame($client, 'link[rel="prev"]', 'href', '/articles');
+        self::asserAttributeValueSame($client, 'link[rel="canonical"]', 'href', '/articles?page=2');
+        self::assertSelectorNotExists('link[rel="next"]');
+    }
+
+    private static function asserAttributeValueSame(KernelBrowser $client, string $selector, string $attribute, string $expectedValue, string $message = ''): void
+    {
+        self::assertThat($client->getCrawler(), LogicalAnd::fromConstraints(
+            new CrawlerSelectorExists($selector),
+            new CrawlerSelectorAttributeValueSame($selector, $attribute, $expectedValue),
+        ), $message);
     }
 }


### PR DESCRIPTION
Permet d'améliorer l'indexation des pages "paginées" du projet :
- corrige le duplicate content entre l'URL `/articles` et `/articles?page=1`
- corrige le même titre pour toute les pages `Planète PHP`
- indique les liens de pagination aux moteurs de recherche `<link rel="prev" [...] />` et  `<link rel="next" [...] />`
